### PR TITLE
fix: corrigir filtro de disponibilidade que bloqueava serviços além do expediente

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -156,6 +156,7 @@
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
         "js-tokens": "^4.0.0",
@@ -171,6 +172,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -272,7 +274,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -316,7 +317,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -929,7 +929,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.6.tgz",
       "integrity": "sha512-4uyt8BOrBsSq6i4yiOV/gG6BnnrvTeyymlNcaN/dKvyU1GoolxAafvIvaNP1RCGPlNab3OuE4MKUQuv2lH+PLQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -996,7 +995,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.6.tgz",
       "integrity": "sha512-YYGARbutghQY4zZUWMYia0ib0Y/rb52y72/N0z3vglRHL7ii/AaK9SA7S/dzScVOlCdnbHXz+sc5Dq+r8fwFAg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.6",
         "@firebase/component": "0.7.0",
@@ -1012,8 +1010,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-compat": {
       "version": "0.6.1",
@@ -1464,7 +1461,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -3732,7 +3728,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3851,7 +3848,6 @@
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3863,7 +3859,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -3914,7 +3909,6 @@
       "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.38.0",
         "@typescript-eslint/types": "8.38.0",
@@ -4247,7 +4241,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -4285,7 +4278,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4407,6 +4399,7 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -4530,7 +4523,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5027,7 +5019,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5087,6 +5078,7 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -5114,7 +5106,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5156,8 +5149,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5274,7 +5266,6 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6101,7 +6092,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -6291,6 +6281,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6658,7 +6649,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6799,6 +6789,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6814,6 +6805,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6824,6 +6816,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6836,7 +6829,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6914,7 +6908,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6941,7 +6934,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6955,7 +6947,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.61.1.tgz",
       "integrity": "sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -7638,7 +7629,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -7762,7 +7752,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7912,7 +7901,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8091,7 +8079,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/services/availability-processor.test.ts
+++ b/src/services/availability-processor.test.ts
@@ -324,6 +324,13 @@ describe("availability-processor", () => {
     });
 
     it("deve calcular corretamente slots necessários para serviço em horas", () => {
+      // Terça-feira: 18:00-20:00. Serviço de 2h. Agendado às 19:00.
+      // - 18:00 bloqueado: precisa de 18:00, 18:30, 19:00*, 19:30 (19:00 ocupado)
+      // - 18:30 bloqueado: precisa de 18:30, 19:00*, 19:30, 20:00 (19:00 ocupado)
+      // - 19:30 DISPONÍVEL: precisa de 19:30, 20:00, 20:30, 21:00 — nenhum ocupado.
+      //   O serviço termina às 21:30 (além das 20:00 do expediente), mas isso é permitido
+      //   pela regra de negócio — o fim do expediente define quando novos slots INICIAM,
+      //   não quando o serviço precisa terminar.
       const service2hours: Service = {
         ...mockService,
         duration: 2,
@@ -347,7 +354,8 @@ describe("availability-processor", () => {
         (slot) => slot.date === "2024-01-16"
       );
 
-      expect(tercaSlots.length).toBe(0);
+      expect(tercaSlots.length).toBe(1);
+      expect(tercaSlots.find((s) => s.time === "19:30")).toBeDefined();
     });
 
     it("deve permitir serviço de 1h quando há espaço suficiente", () => {
@@ -556,6 +564,99 @@ describe("availability-processor", () => {
       expect(tercaSlots.find((s) => s.time === "18:30")).toBeDefined();
       expect(tercaSlots.find((s) => s.time === "19:00")).toBeUndefined();
       expect(tercaSlots.find((s) => s.time === "19:30")).toBeUndefined();
+    });
+
+    it("REGRA DE NEGÓCIO: deve permitir agendamento cujo término ultrapassa o fim do expediente", () => {
+      // O horário de fim do expediente define até quando novos slots podem INICIAR,
+      // não impede que o serviço se estenda além dele. Esse teste documenta esse
+      // comportamento para evitar regressão.
+      const service3h30: Service = {
+        id: "service-3h30",
+        name: "Serviço 3h30",
+        color: "#F4A69F",
+        duration: 210,
+        durationUnit: "min",
+        advanceDays: 0,
+      };
+
+      const availability: Availability = {
+        userId: "user-1",
+        schedule: [
+          { day: "Segunda-feira", enabled: true, start: "18:00", end: "19:30" },
+          { day: "Terça-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Quarta-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Quinta-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Sexta-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Sábado", enabled: false, start: "09:00", end: "14:00" },
+          { day: "Domingo", enabled: false, start: "09:00", end: "14:00" },
+        ],
+        holidaysEnabled: false,
+        holidays: [],
+      };
+
+      // 2024-01-15 é segunda-feira
+      const startDate = new Date("2024-01-15");
+      const endDate = new Date("2024-01-15");
+
+      const result = processAvailability(
+        availability,
+        service3h30,
+        startDate,
+        endDate,
+        []
+      );
+
+      // Deve mostrar os slots das 18:00 e 18:30 (únicos slots gerados dentro do expediente)
+      // mesmo que o serviço de 3h30 termine às 21:30 / 22:00, bem além das 19:30
+      expect(result.availableSlots.length).toBeGreaterThan(0);
+      expect(result.availableSlots.find((s) => s.time === "18:00")).toBeDefined();
+      expect(result.availableSlots.find((s) => s.time === "18:30")).toBeDefined();
+    });
+
+    it("REGRA DE NEGÓCIO: serviço de 3h30 deve desaparecer somente quando slots estiverem ocupados", () => {
+      const service3h30: Service = {
+        id: "service-3h30",
+        name: "Serviço 3h30",
+        color: "#F4A69F",
+        duration: 210,
+        durationUnit: "min",
+        advanceDays: 0,
+      };
+
+      const availability: Availability = {
+        userId: "user-1",
+        schedule: [
+          { day: "Segunda-feira", enabled: true, start: "18:00", end: "19:30" },
+          { day: "Terça-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Quarta-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Quinta-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Sexta-feira", enabled: false, start: "08:00", end: "18:00" },
+          { day: "Sábado", enabled: false, start: "09:00", end: "14:00" },
+          { day: "Domingo", enabled: false, start: "09:00", end: "14:00" },
+        ],
+        holidaysEnabled: false,
+        holidays: [],
+      };
+
+      const startDate = new Date("2024-01-15");
+      const endDate = new Date("2024-01-15");
+      // Ocupa um slot no meio do período necessário para o serviço de 3h30 às 18:00
+      const bookedSlots = [{ date: "2024-01-15", time: "19:00" }];
+
+      const result = processAvailability(
+        availability,
+        service3h30,
+        startDate,
+        endDate,
+        bookedSlots
+      );
+
+      // 18:00 bloqueado porque 19:00 (slot necessário) está ocupado
+      expect(result.availableSlots.find((s) => s.time === "18:00")).toBeUndefined();
+      // 18:30 ainda aparece pois 19:00 não faz parte do bloco que começa às 18:30
+      // (18:30 → 19:00 → 19:30 → 20:00 → ... → 22:00 — o slot 19:00 ocupa exatamente às 19:00)
+      // Na verdade 18:30 + 30min = 19:00, logo 19:00 É necessário para o slot das 18:30 também
+      expect(result.availableSlots.find((s) => s.time === "18:30")).toBeUndefined();
     });
 
     it("deve ordenar slots por data e hora", () => {

--- a/src/services/availability-processor.ts
+++ b/src/services/availability-processor.ts
@@ -194,8 +194,7 @@ const generateAvailableSlots = (
 const filterSlotsByServiceDuration = (
   slots: AvailableSlot[],
   service: Service,
-  bookedSlots: { date: string; time: string }[],
-  enabledDays: DaySchedule[]
+  bookedSlots: { date: string; time: string }[]
 ): AvailableSlot[] => {
   if (!service.duration) {
     return slots;
@@ -232,17 +231,6 @@ const filterSlotsByServiceDuration = (
     const slotDate = new Date(slot.dateTime);
     const serviceEnd = new Date(slotDate);
     serviceEnd.setMinutes(serviceEnd.getMinutes() + durationMinutes);
-
-    const dayName = getDayName(slotDate);
-    const daySchedule = enabledDays.find((day) => day.day === dayName);
-    if (daySchedule) {
-      const [endHour, endMin] = daySchedule.end.split(":").map(Number);
-      const dayEnd = new Date(slotDate);
-      dayEnd.setHours(endHour, endMin, 0, 0);
-      if (serviceEnd.getTime() > dayEnd.getTime()) {
-        return false;
-      }
-    }
 
     const currentSlot = new Date(slotDate);
     const slotDuration = 30;
@@ -284,7 +272,7 @@ export const processAvailability = (
   
   slots = removeBookedAppointments(slots, bookedSlots);
   
-  slots = filterSlotsByServiceDuration(slots, service, bookedSlots, enabledDays);
+  slots = filterSlotsByServiceDuration(slots, service, bookedSlots);
   
   slots.sort((a, b) => a.dateTime.getTime() - b.dateTime.getTime());
 


### PR DESCRIPTION
## Problema

O PR #21 introduziu acidentalmente uma validação em `filterSlotsByServiceDuration` (`availability-processor.ts`) que rejeitava qualquer slot cujo término ultrapassasse o fim do expediente da profissional.

**Cenário afetado:** profissional com horário 18:00–19:30 (seg–sex) + serviço de 3h30. Como 18:00 + 3h30 = 21:30 > 19:30, todos os slots eram rejeitados → zero horários disponíveis para a cliente.

## Regra de negócio

O horário de fim do expediente define **quando novos slots podem INICIAR**, não quando o serviço precisa terminar. Um agendamento iniciado dentro do expediente pode se estender além dele.

## Mudanças

- Remove a validação `if (serviceEnd > dayEnd) return false` de `filterSlotsByServiceDuration`
- Remove o parâmetro `enabledDays` que ficou sem uso na função
- Adiciona testes que documentam explicitamente a regra de negócio para evitar regressão futura

## Testes

24/24 passando. Os novos testes incluem:
- Serviço de 3h30 em janela de 18:00–19:30 deve mostrar slots disponíveis
- Serviço de 2h com slot 19:00 ocupado: 18:00 e 18:30 bloqueados, mas 19:30 disponível (termina às 21:30, além do expediente de 20:00)

https://claude.ai/code/session_019JPduJSZoJf9xSLmWVFVgc