### PR TITLE
feat: pré-preencher telefone via parâmetro phoneNumber na URL

### DIFF
--- a/src/pages/BookingPublic.test.tsx
+++ b/src/pages/BookingPublic.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+const { mockUseSearchParams, mockUseParams, mockUseBookingData, mockGetExcludedDays } =
+  vi.hoisted(() => ({
+    mockUseSearchParams: vi.fn(),
+    mockUseParams: vi.fn(),
+    mockUseBookingData: vi.fn(),
+    mockGetExcludedDays: vi.fn(),
+  }));
+
+vi.mock("react-router-dom", () => ({
+  useParams: mockUseParams,
+  useSearchParams: mockUseSearchParams,
+}));
+
+vi.mock("@/hooks/use-booking-data", () => ({
+  useBookingData: mockUseBookingData,
+}));
+
+vi.mock("@/services/excluded-days", () => ({
+  getExcludedDays: mockGetExcludedDays,
+}));
+
+vi.mock("@/services/appointments", () => ({
+  createAppointment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("firebase/firestore", () => ({
+  Timestamp: { fromDate: vi.fn(() => ({})) },
+}));
+
+// Layout components — not under test
+vi.mock("@/components/booking/BookingHeader", () => ({
+  BookingHeader: () => <div />,
+}));
+
+vi.mock("@/components/booking/ProgressIndicator", () => ({
+  ProgressIndicator: () => <div />,
+}));
+
+vi.mock("@/components/booking/SuccessStep", () => ({
+  SuccessStep: () => <div />,
+}));
+
+// Step 1 — clicking the button calls onSelect with the first service
+vi.mock("@/components/booking/ServiceSelectionStep", () => ({
+  ServiceSelectionStep: ({ onSelect, services }: any) => (
+    <button onClick={() => onSelect(services[0])}>select-service</button>
+  ),
+}));
+
+// Step 2 — clicking the button calls onTimeSelect with a fixed date/time
+vi.mock("@/components/booking/DateTimeSelectionStep", () => ({
+  DateTimeSelectionStep: ({ onTimeSelect }: any) => (
+    <button onClick={() => onTimeSelect("2024-05-01", "10:00")}>select-time</button>
+  ),
+}));
+
+// ConfirmationStep is NOT mocked — we verify the real phone input value
+
+import BookingPublic from "./BookingPublic";
+
+const MOCK_SERVICES = [
+  { id: "s1", name: "Corte de Cabelo", duration: 30, durationUnit: "min" as const, price: 50 },
+];
+
+const DEFAULT_BOOKING_DATA = {
+  services: MOCK_SERVICES,
+  availability: null,
+  userId: "user-123",
+  logoUrl: null,
+  bookedSlots: [],
+  isLoading: false,
+  error: null,
+};
+
+async function renderAndGoToStep3() {
+  await act(async () => {
+    render(<BookingPublic />);
+  });
+  fireEvent.click(screen.getByText("select-service"));
+  fireEvent.click(screen.getByText("select-time"));
+}
+
+describe("BookingPublic – parâmetro phoneNumber na URL", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseParams.mockReturnValue({ userLink: "meu-link" });
+    mockUseBookingData.mockReturnValue(DEFAULT_BOOKING_DATA);
+    mockGetExcludedDays.mockResolvedValue([]);
+  });
+
+  it("pré-preenche o campo telefone quando phoneNumber está na URL", async () => {
+    mockUseSearchParams.mockReturnValue([new URLSearchParams("phoneNumber=11999998888")]);
+
+    await renderAndGoToStep3();
+
+    const phoneInput = screen.getByPlaceholderText("(00) 00000-0000") as HTMLInputElement;
+    expect(phoneInput.value).toBe("11999998888");
+  });
+
+  it("deixa o campo telefone vazio quando o parâmetro phoneNumber não está presente", async () => {
+    mockUseSearchParams.mockReturnValue([new URLSearchParams("")]);
+
+    await renderAndGoToStep3();
+
+    const phoneInput = screen.getByPlaceholderText("(00) 00000-0000") as HTMLInputElement;
+    expect(phoneInput.value).toBe("");
+  });
+
+  it("permite o usuário editar o telefone pré-preenchido", async () => {
+    mockUseSearchParams.mockReturnValue([new URLSearchParams("phoneNumber=11999998888")]);
+
+    await renderAndGoToStep3();
+
+    const phoneInput = screen.getByPlaceholderText("(00) 00000-0000") as HTMLInputElement;
+    fireEvent.change(phoneInput, { target: { value: "21988887777" } });
+    expect(phoneInput.value).toBe("21988887777");
+  });
+});

--- a/src/pages/BookingPublic.tsx
+++ b/src/pages/BookingPublic.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams } from "react-router-dom";
 import { Sparkles, AlertCircle } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { toast } from "sonner";
@@ -20,8 +20,9 @@ import { getExcludedDays } from "@/services/excluded-days";
 
 const BookingPublic = () => {
   const { userLink } = useParams<{ userLink: string }>();
+  const [searchParams] = useSearchParams();
   const { services, availability, userId, logoUrl, bookedSlots, isLoading, error } = useBookingData({ userLink: userLink || null });
-  
+
   const [step, setStep] = useState(1);
   const [selectedService, setSelectedService] = useState<Service | null>(null);
   const [selectedDate, setSelectedDate] = useState("");
@@ -30,7 +31,7 @@ const BookingPublic = () => {
   const [isSuccess, setIsSuccess] = useState(false);
   const [formData, setFormData] = useState({
     name: "",
-    phone: "",
+    phone: searchParams.get("phoneNumber") || "",
     notes: "",
   });
   const [excludedDays, setExcludedDays] = useState<string[]>([]);


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Lê o query param `phoneNumber` da URL de agendamento do profissional
- Se presente, pré-preenche automaticamente o campo de telefone na etapa de confirmação (Step 3)
- Sem impacto em fluxos sem o parâmetro — o campo continua vazio como antes

## Uso

```
/book/:userLink?phoneNumber=11999998888
```

## Test plan

- [ ] Acessar `/book/:userLink` sem o parâmetro — campo telefone vazio (comportamento atual)
- [ ] Acessar `/book/:userLink?phoneNumber=11999998888` — campo telefone pré-preenchido com `11999998888`
- [ ] Verificar que o valor pode ser editado normalmente pelo usuário
- [ ] Confirmar agendamento e checar que o `clientPhone` salvo é o correto

https://claude.ai/code/session_01JNH5VobdEtVeBkFHpfiR3X
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNH5VobdEtVeBkFHpfiR3X)_