### PR TITLE
feat: scroll automático para horários ao selecionar data

### DIFF
--- a/src/components/booking/DateTimeSelectionStep.tsx
+++ b/src/components/booking/DateTimeSelectionStep.tsx
@@ -1,3 +1,4 @@
+import { useRef, useEffect } from "react";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Service } from "@/services/user-services";
@@ -29,6 +30,16 @@ export const DateTimeSelectionStep = ({
   onTimeSelect,
   onBack,
 }: DateTimeSelectionStepProps) => {
+  const timeSlotsRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (selectedDate && timeSlotsRef.current) {
+      setTimeout(() => {
+        timeSlotsRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }, 50);
+    }
+  }, [selectedDate]);
+
   return (
     <div className="bg-card rounded-[20px] border border-border shadow-soft overflow-hidden animate-slide-up">
       <div className="px-6 py-5 border-b border-border">
@@ -74,7 +85,7 @@ export const DateTimeSelectionStep = ({
 
         {/* Time selection */}
         {selectedDate && availableTimesForDate.length > 0 && (
-          <div className="space-y-3 animate-slide-up">
+          <div ref={timeSlotsRef} className="space-y-3 animate-slide-up">
             <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
               Horário disponível
             </p>
@@ -97,7 +108,7 @@ export const DateTimeSelectionStep = ({
         )}
 
         {selectedDate && availableTimesForDate.length === 0 && (
-          <p className="text-center text-sm text-muted-foreground py-4">
+          <p ref={timeSlotsRef} className="text-center text-sm text-muted-foreground py-4">
             Nenhum horário disponível para esta data
           </p>
         )}


### PR DESCRIPTION
## Summary

- Adiciona scroll suave automático para a seção de horários disponíveis após o cliente selecionar uma data
- Cobre os dois casos: quando há horários disponíveis e quando não há
- O scroll usa `scrollIntoView({ behavior: "smooth", block: "start" })` com um pequeno delay de 50ms para aguardar a animação de entrada do elemento

## Test plan

- [ ] Abrir a página de agendamento público de um profissional com muitas datas disponíveis
- [ ] Selecionar uma data — verificar que a página faz scroll suave até os horários
- [ ] Selecionar outra data — verificar que o scroll ocorre novamente
- [ ] Selecionar uma data sem horários disponíveis — verificar que a mensagem "Nenhum horário disponível" também recebe o scroll

https://claude.ai/code/session_01QJQUbqWcmN3iSvFgXrzVod

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJQUbqWcmN3iSvFgXrzVod)_