### PR TITLE
feat: relatórios para a profissional

### DIFF
--- a/docs/RELATORIOS_PROFISSIONAL.md
+++ b/docs/RELATORIOS_PROFISSIONAL.md
@@ -21,6 +21,7 @@ agendamentos que já existem no sistema. A feature deve responder perguntas como
 | **Receita / faturamento** | **Fora desta versão.** Hoje não existe campo de preço em `user_services` nem em `appointments`. Relatórios focam em métricas **operacionais**. Receita fica como fase futura (ver §8). |
 | **Localização** | **Nova página dedicada `/reports`**, acessível por um card no Dashboard, seguindo o padrão das telas existentes. |
 | **Escopo** | **Completo**: KPIs + gráficos + retenção de clientes + top clientes + taxas de cancelamento/no-show + comparação entre períodos + exportação. |
+| **No-show** | **Incluído nesta versão.** Adiciona o status `no_show` ao agendamento, ação manual "Não compareceu" na Agenda e inferência de faltas em aberto no relatório (ver §3.5 e Fase 0 em §7). |
 
 ## 2. Contexto técnico (estado atual)
 
@@ -45,7 +46,7 @@ interface Appointment {
   dateTime: Timestamp;        // ordenável / filtrável por período
   duration?: number;
   durationUnit?: "min" | "hour";
-  status: "pending" | "confirmed" | "cancelled" | "completed";
+  status: "pending" | "confirmed" | "cancelled" | "completed" | "no_show"; // no_show adicionado nesta feature
   createdAt: Timestamp;
   updatedAt: Timestamp;
 }
@@ -53,9 +54,9 @@ interface Appointment {
 
 `user_services` (`src/services/user-services.ts`): `id, name, color, duration, durationUnit, advanceDays`.
 
-> **Importante**: não existe campo `noShow`. "Não compareceu" não é representável hoje
-> sem evolução do modelo (ver §8). Nesta versão tratamos os status existentes:
-> `completed`, `confirmed`, `pending`, `cancelled`.
+> **No-show**: o status `no_show` **não existe hoje** e será adicionado por esta feature
+> (sem migração — documentos antigos seguem válidos). A captura é manual na Agenda e o
+> relatório complementa com inferência de faltas em aberto. Detalhes em §3.5 e Fase 0 (§7).
 
 ### O que já existe e vamos reutilizar
 
@@ -74,7 +75,9 @@ interface Appointment {
 |-----|---------|------------|
 | Total de agendamentos | contagem no período | vs. período anterior (Δ%) |
 | Atendimentos concluídos | status `completed` | vs. período anterior |
+| Taxa de comparecimento | `completed / (completed + cancelled + no_show)` | vs. período anterior |
 | Taxa de cancelamento | `cancelled / total` | vs. período anterior |
+| Faltas (no-show) | status `no_show` | vs. período anterior |
 | Clientes únicos | `clientPhone` distintos | vs. período anterior |
 | Clientes recorrentes | clientes com ≥ 2 agendamentos no período | — |
 | Ticket de tempo (opcional) | soma de `duration` (horas agendadas) | vs. período anterior |
@@ -89,7 +92,7 @@ período anterior de mesma duração.
 2. **Serviços mais populares** — gráfico de barras horizontais, ordenado por contagem,
    usando a `color` de cada serviço.
 3. **Distribuição por status** — gráfico de pizza/donut (`completed`, `confirmed`,
-   `pending`, `cancelled`) com legenda.
+   `pending`, `cancelled`, `no_show`) com legenda.
 4. **Mapa de calor de horários** (opcional, fase 2 da implementação) — dias da semana × faixa de horário,
    para identificar os horários mais movimentados.
 
@@ -104,6 +107,33 @@ período anterior de mesma duração.
 - Seletor de período: **Últimos 7 dias / 30 dias / Este mês / Mês passado / Este ano / Personalizado**.
 - Período personalizado via date range picker.
 - Os cálculos de comparação usam o período imediatamente anterior de mesma duração.
+
+### 3.5 Tratamento de no-show (faltas)
+
+O problema: hoje o modelo não distingue "cliente não compareceu" de "agendamento que a
+profissional esqueceu de dar baixa". Resolvemos em três camadas:
+
+1. **Modelo** — novo status terminal `no_show` no agendamento. Sem migração: documentos
+   existentes continuam válidos; o status só é atribuído daqui para frente.
+
+2. **Captura manual (fonte de verdade)** — na Agenda, agendamentos passados ganham a ação
+   **"Não compareceu"**, ao lado de concluir/cancelar. A profissional, que conhece a
+   realidade do atendimento, faz a marcação. Esta é a base das métricas de no-show.
+
+3. **Inferência (apoio operacional)** — o relatório classifica como **"faltas em aberto"**
+   os agendamentos cuja `dateTime` já passou e que seguem em `pending`/`confirmed`
+   (nunca viraram `completed`/`cancelled`/`no_show`). É uma métrica **separada**, exibida
+   como alerta ("X atendimentos pendentes de baixa"), que **não** entra na contagem de
+   no-show confirmado — evita inflar a métrica e incentiva fechar o status na Agenda.
+
+Métricas resultantes no relatório:
+
+| Métrica | Definição |
+|---------|-----------|
+| Cancelamentos | status `cancelled` (cliente avisou) |
+| Faltas (no-show) | status `no_show` (cliente não avisou e não veio) |
+| Taxa de comparecimento | `completed / (completed + cancelled + no_show)` |
+| Faltas em aberto | inferido: passado e ainda `pending`/`confirmed` (alerta, não no-show) |
 
 ## 4. Arquitetura da implementação
 
@@ -123,7 +153,10 @@ export interface ReportMetrics {
   cancelled: number;
   pending: number;
   confirmed: number;
+  noShow: number;               // status no_show (falta confirmada)
+  openNoShow: number;           // inferido: passado e ainda pending/confirmed
   cancellationRate: number;     // 0..1
+  attendanceRate: number;       // completed / (completed + cancelled + no_show)
   uniqueClients: number;
   returningClients: number;
   totalScheduledMinutes: number;
@@ -254,7 +287,8 @@ download via Blob. Sem dependência nova.
 
 | Fase | Entrega | Arquivos |
 |------|---------|----------|
-| **1** | Camada de serviço + testes unitários das agregações | `services/reports.ts`, `*.test.ts` |
+| **0** | Status `no_show`: adicionar ao tipo `Appointment`; função/cloud function para atualizar status; ação "Não compareceu" (e badge correspondente) no `AppointmentDetailsSheet` | `services/appointments.ts`, `components/calendar/AppointmentDetailsSheet.tsx` |
+| **1** | Camada de serviço + testes unitários das agregações (inclui no-show e faltas em aberto) | `services/reports.ts`, `*.test.ts` |
 | **2** | Hook + página com KPIs e gráfico de tendência | `hooks/use-reports.tsx`, `pages/Reports.tsx`, rota, card no Dashboard |
 | **3** | Gráficos de serviços/status + tabelas (top clientes, resumo) | `components/reports/*` |
 | **4** | Filtros de período + comparação vs. período anterior | `PeriodSelector`, lógica de comparação |
@@ -268,8 +302,6 @@ Cada fase é commitável e revisável de forma independente.
   valor cobrado no `appointment` (snapshot no momento da reserva, para preservar
   histórico mesmo se o preço do serviço mudar). Habilita: faturamento por período,
   ticket médio, receita por serviço, projeção. **Recomendado como próxima feature.**
-- **No-show**: adicionar status/flag `noShow` ao agendamento (e ação na agenda para
-  marcá-lo) para distinguir de cancelamento. Necessário para taxa de comparecimento real.
 - **Entidade Cliente**: hoje o cliente é inferido por `clientPhone`. Uma coleção
   `clients` permitiria histórico, observações e métricas de retenção mais ricas (LTV, frequência média).
 - **Relatórios agendados por e-mail** (resumo semanal/mensal via Cloud Function).
@@ -286,6 +318,9 @@ Cada fase é commitável e revisável de forma independente.
 | Novo | `src/components/reports/{KpiCard,AppointmentsTrendChart,ServicePopularityChart,StatusDistributionChart,TopClientsTable,PeriodSelector}.tsx` |
 | Editar | `src/App.tsx` (rota `/reports`) |
 | Editar | `src/pages/Dashboard.tsx` (card "Relatórios") |
-| Reutilizar | `src/components/ui/chart.tsx`, `src/services/appointments.ts`, `src/services/user-services.ts` |
+| Editar | `src/services/appointments.ts` (status `no_show` + atualização de status) |
+| Editar | `src/components/calendar/AppointmentDetailsSheet.tsx` (ação "Não compareceu" + badge) |
+| Reutilizar | `src/components/ui/chart.tsx`, `src/services/user-services.ts` |
 
-**Sem novas dependências. Sem mudanças no modelo de dados nesta versão.**
+**Sem novas dependências.** Única mudança de modelo: novo valor de status `no_show`
+(aditivo, sem migração de dados).

--- a/docs/RELATORIOS_PROFISSIONAL.md
+++ b/docs/RELATORIOS_PROFISSIONAL.md
@@ -1,0 +1,291 @@
+# Planejamento — Feature de Relatórios para a Profissional
+
+> Status: Planejamento • Branch: `claude/professional-reports-planning-2229k5`
+> Última atualização: 2026-06-14
+
+## 1. Objetivo
+
+Dar à profissional uma visão analítica do seu negócio a partir dos dados de
+agendamentos que já existem no sistema. A feature deve responder perguntas como:
+
+- Quantos atendimentos eu fiz este mês? E comparado ao mês passado?
+- Quais serviços são os mais procurados?
+- Quantos agendamentos foram cancelados ou não compareceram (no-show)?
+- Quem são meus clientes mais frequentes? Quantos voltam?
+- Como está a distribuição dos meus atendimentos ao longo do tempo?
+
+### Decisões de escopo (alinhadas com a profissional)
+
+| Tema | Decisão |
+|------|---------|
+| **Receita / faturamento** | **Fora desta versão.** Hoje não existe campo de preço em `user_services` nem em `appointments`. Relatórios focam em métricas **operacionais**. Receita fica como fase futura (ver §8). |
+| **Localização** | **Nova página dedicada `/reports`**, acessível por um card no Dashboard, seguindo o padrão das telas existentes. |
+| **Escopo** | **Completo**: KPIs + gráficos + retenção de clientes + top clientes + taxas de cancelamento/no-show + comparação entre períodos + exportação. |
+
+## 2. Contexto técnico (estado atual)
+
+- **Stack**: React 18 + TypeScript + Vite, React Router v6, TanStack Query, shadcn/ui (Radix + Tailwind), **Recharts já instalado** (`src/components/ui/chart.tsx`).
+- **Backend**: Firebase Firestore (NoSQL). Cada profissional é o `auth.uid`; todos os documentos são filtrados por `userId`.
+- **Padrão de dados**: camada `src/services/*.ts` (queries Firestore) → hooks `src/hooks/use-*.tsx` (estado + cache) → páginas `src/pages/*.tsx`.
+
+### Modelo de dados relevante
+
+`appointments` (`src/services/appointments.ts`):
+
+```ts
+interface Appointment {
+  id?: string;
+  userId: string;
+  serviceId: string;
+  serviceName: string;
+  clientName: string;
+  clientPhone: string;        // usado como identificador de cliente (não há entidade Cliente)
+  date: string;               // yyyy-MM-dd
+  time: string;               // HH:mm
+  dateTime: Timestamp;        // ordenável / filtrável por período
+  duration?: number;
+  durationUnit?: "min" | "hour";
+  status: "pending" | "confirmed" | "cancelled" | "completed";
+  createdAt: Timestamp;
+  updatedAt: Timestamp;
+}
+```
+
+`user_services` (`src/services/user-services.ts`): `id, name, color, duration, durationUnit, advanceDays`.
+
+> **Importante**: não existe campo `noShow`. "Não compareceu" não é representável hoje
+> sem evolução do modelo (ver §8). Nesta versão tratamos os status existentes:
+> `completed`, `confirmed`, `pending`, `cancelled`.
+
+### O que já existe e vamos reutilizar
+
+- `getAppointmentsByDateRange(userId, startDate, endDate)` — base para todas as queries.
+- `getAppointmentsByUserId(userId)` — fallback para visão histórica completa.
+- `getUserServices(userId)` — nomes e cores dos serviços (cores reaproveitadas nos gráficos).
+- `ChartContainer / ChartTooltip / ChartLegend` (`src/components/ui/chart.tsx`) — wrapper Recharts com tema Tailwind.
+- Componentes shadcn: `Card`, `Tabs`, `Select`, `Table`, `Badge`, `Button`.
+- `src/lib/analytics.ts` — para rastrear o uso da própria tela de relatórios.
+
+## 3. Métricas e visualizações
+
+### 3.1 KPIs (cards no topo)
+
+| KPI | Cálculo | Comparação |
+|-----|---------|------------|
+| Total de agendamentos | contagem no período | vs. período anterior (Δ%) |
+| Atendimentos concluídos | status `completed` | vs. período anterior |
+| Taxa de cancelamento | `cancelled / total` | vs. período anterior |
+| Clientes únicos | `clientPhone` distintos | vs. período anterior |
+| Clientes recorrentes | clientes com ≥ 2 agendamentos no período | — |
+| Ticket de tempo (opcional) | soma de `duration` (horas agendadas) | vs. período anterior |
+
+Cada card mostra valor atual + variação percentual colorida (verde/vermelho) vs. o
+período anterior de mesma duração.
+
+### 3.2 Gráficos
+
+1. **Agendamentos ao longo do tempo** — gráfico de linha/área (Recharts `AreaChart`).
+   Agrupamento por dia/semana/mês conforme o período selecionado.
+2. **Serviços mais populares** — gráfico de barras horizontais, ordenado por contagem,
+   usando a `color` de cada serviço.
+3. **Distribuição por status** — gráfico de pizza/donut (`completed`, `confirmed`,
+   `pending`, `cancelled`) com legenda.
+4. **Mapa de calor de horários** (opcional, fase 2 da implementação) — dias da semana × faixa de horário,
+   para identificar os horários mais movimentados.
+
+### 3.3 Tabelas
+
+1. **Top clientes** — nome, telefone, nº de agendamentos, último atendimento.
+   Ordenável; destaca recorrentes.
+2. **Resumo por serviço** — serviço, nº de agendamentos, % do total, tempo total agendado.
+
+### 3.4 Filtros
+
+- Seletor de período: **Últimos 7 dias / 30 dias / Este mês / Mês passado / Este ano / Personalizado**.
+- Período personalizado via date range picker.
+- Os cálculos de comparação usam o período imediatamente anterior de mesma duração.
+
+## 4. Arquitetura da implementação
+
+Seguindo o padrão existente (service → hook → page), nenhuma dependência nova é necessária.
+
+### 4.1 Camada de serviço — `src/services/reports.ts` (novo)
+
+Funções puras de agregação no cliente (a base de dados é por-usuário e os volumes são
+pequenos; agregação client-side é suficiente para o MVP completo):
+
+```ts
+export interface ReportPeriod { start: Date; end: Date; }
+
+export interface ReportMetrics {
+  totalAppointments: number;
+  completed: number;
+  cancelled: number;
+  pending: number;
+  confirmed: number;
+  cancellationRate: number;     // 0..1
+  uniqueClients: number;
+  returningClients: number;
+  totalScheduledMinutes: number;
+}
+
+export interface ServiceBreakdown {
+  serviceId: string;
+  serviceName: string;
+  color: string;
+  count: number;
+  percentage: number;
+  totalMinutes: number;
+}
+
+export interface ClientSummary {
+  clientName: string;
+  clientPhone: string;
+  appointmentsCount: number;
+  lastAppointment: Date;
+}
+
+export interface TimeSeriesPoint { label: string; date: string; count: number; }
+
+// Busca o dataset uma vez e deriva tudo a partir dele:
+export async function getReportData(userId: string, period: ReportPeriod): Promise<{
+  current: Appointment[];
+  previous: Appointment[];  // período anterior de mesma duração, para comparação
+}>;
+
+export function computeMetrics(appts: Appointment[]): ReportMetrics;
+export function computeServiceBreakdown(appts: Appointment[], services: Service[]): ServiceBreakdown[];
+export function computeTopClients(appts: Appointment[], limit?: number): ClientSummary[];
+export function computeTimeSeries(appts: Appointment[], granularity: "day" | "week" | "month"): TimeSeriesPoint[];
+```
+
+> As funções `compute*` são **puras** (entram arrays, saem agregados) → fáceis de testar
+> com Vitest, sem mockar Firestore.
+
+### 4.2 Hook — `src/hooks/use-reports.tsx` (novo)
+
+```ts
+export function useReports({ userId, period }: {
+  userId: string | null;
+  period: ReportPeriod;
+}) {
+  // Usa TanStack Query (useQuery) com key ["reports", userId, period.start, period.end]
+  // Retorna: metrics, previousMetrics, serviceBreakdown, topClients, timeSeries,
+  //          statusDistribution, isLoading, error, refetch
+}
+```
+
+### 4.3 Página — `src/pages/Reports.tsx` (novo)
+
+Layout (reutiliza estética dos cards `rounded-[20px] border border-border shadow-soft`):
+
+```
+Header: "Relatórios" + seletor de período (Select / date range)
+─ Grid de KPI cards (4–6 cards com Δ% vs. período anterior)
+─ Card: Agendamentos ao longo do tempo (AreaChart)
+─ Grid 2 colunas:
+    • Card: Serviços mais populares (BarChart)
+    • Card: Distribuição por status (PieChart/donut)
+─ Card: Top clientes (Table)
+─ Card: Resumo por serviço (Table)
+─ Botão "Exportar CSV"
+```
+
+Estados de loading (spinner igual ao Dashboard) e empty state ("Ainda não há
+agendamentos neste período").
+
+### 4.4 Componentes auxiliares — `src/components/reports/` (novos)
+
+- `KpiCard.tsx` — valor, label, ícone (lucide), Δ% colorido.
+- `AppointmentsTrendChart.tsx`
+- `ServicePopularityChart.tsx`
+- `StatusDistributionChart.tsx`
+- `TopClientsTable.tsx`
+- `PeriodSelector.tsx`
+
+### 4.5 Roteamento — `src/App.tsx` (editar)
+
+```tsx
+<Route path="/reports" element={<ProtectedRoute><Reports /></ProtectedRoute>} />
+```
+
+### 4.6 Entrada no Dashboard — `src/pages/Dashboard.tsx` (editar)
+
+Adicionar item ao `menuItems`:
+
+```ts
+{
+  title: "Relatórios",
+  description: "Acompanhe métricas e o desempenho do seu negócio",
+  icon: BarChart3,            // de lucide-react
+  path: "/reports",
+}
+```
+
+### 4.7 Exportação CSV
+
+Gerar CSV no cliente (lista de agendamentos do período + abas de resumo) e disparar
+download via Blob. Sem dependência nova.
+
+## 5. Considerações de dados e performance
+
+- **Volume**: agendamentos por profissional são na casa de dezenas/centenas → buscar o
+  período e agregar no cliente é adequado. Evita custo/complexidade de aggregation queries.
+- **Comparação de período**: uma única função calcula `[start, end]` e o período anterior
+  `[start - duração, start]` e reaproveita `getAppointmentsByDateRange`.
+- **Índices Firestore**: as queries atuais filtram só por `userId` (sem índice composto).
+  Mantemos esse padrão — nenhum índice novo necessário.
+- **Identidade do cliente**: `clientPhone` é a chave de deduplicação (não há entidade
+  Cliente). Normalizar o telefone (remover espaços/símbolos) antes de agrupar.
+- **Cancelados**: incluídos nas contagens de status, mas **excluídos** dos cálculos de
+  "atendimentos realizados" e de tempo agendado.
+- **Fuso horário**: usar `date-fns` (já no projeto) e `dateTime` (Timestamp) como fonte
+  de verdade para agrupamentos.
+
+## 6. Testes
+
+- **Unitários (Vitest)** para `computeMetrics`, `computeServiceBreakdown`,
+  `computeTopClients`, `computeTimeSeries` — fixtures de agendamentos cobrindo:
+  período vazio, cancelamentos, clientes recorrentes, múltiplos serviços, fronteiras de data.
+- **Componente**: render da `Reports` com dados mockados (loading / vazio / preenchido).
+- Verificação manual: rodar `npm run dev`, popular agendamentos de teste e validar os números.
+
+## 7. Plano de entrega (incremental)
+
+| Fase | Entrega | Arquivos |
+|------|---------|----------|
+| **1** | Camada de serviço + testes unitários das agregações | `services/reports.ts`, `*.test.ts` |
+| **2** | Hook + página com KPIs e gráfico de tendência | `hooks/use-reports.tsx`, `pages/Reports.tsx`, rota, card no Dashboard |
+| **3** | Gráficos de serviços/status + tabelas (top clientes, resumo) | `components/reports/*` |
+| **4** | Filtros de período + comparação vs. período anterior | `PeriodSelector`, lógica de comparação |
+| **5** | Exportação CSV + empty/loading states + polimento responsivo | `Reports.tsx` |
+
+Cada fase é commitável e revisável de forma independente.
+
+## 8. Fora de escopo / fases futuras
+
+- **Receita / faturamento**: requer adicionar `price` a `user_services` e gravar o
+  valor cobrado no `appointment` (snapshot no momento da reserva, para preservar
+  histórico mesmo se o preço do serviço mudar). Habilita: faturamento por período,
+  ticket médio, receita por serviço, projeção. **Recomendado como próxima feature.**
+- **No-show**: adicionar status/flag `noShow` ao agendamento (e ação na agenda para
+  marcá-lo) para distinguir de cancelamento. Necessário para taxa de comparecimento real.
+- **Entidade Cliente**: hoje o cliente é inferido por `clientPhone`. Uma coleção
+  `clients` permitiria histórico, observações e métricas de retenção mais ricas (LTV, frequência média).
+- **Relatórios agendados por e-mail** (resumo semanal/mensal via Cloud Function).
+- **Exportação em PDF**.
+
+## 9. Resumo de arquivos
+
+| Ação | Arquivo |
+|------|---------|
+| Novo | `src/services/reports.ts` |
+| Novo | `src/services/reports.test.ts` |
+| Novo | `src/hooks/use-reports.tsx` |
+| Novo | `src/pages/Reports.tsx` |
+| Novo | `src/components/reports/{KpiCard,AppointmentsTrendChart,ServicePopularityChart,StatusDistributionChart,TopClientsTable,PeriodSelector}.tsx` |
+| Editar | `src/App.tsx` (rota `/reports`) |
+| Editar | `src/pages/Dashboard.tsx` (card "Relatórios") |
+| Reutilizar | `src/components/ui/chart.tsx`, `src/services/appointments.ts`, `src/services/user-services.ts` |
+
+**Sem novas dependências. Sem mudanças no modelo de dados nesta versão.**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Services from "./pages/Services";
 import Availability from "./pages/Availability";
 import ExcludedDays from "./pages/ExcludedDays";
 import Appointments from "./pages/Appointments";
+import Reports from "./pages/Reports";
 import Theme from "./pages/Theme";
 import BookingPublic from "./pages/BookingPublic";
 import NotFound from "./pages/NotFound";
@@ -73,6 +74,14 @@ const App = () => (
             element={
               <ProtectedRoute>
                 <Appointments />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/reports"
+            element={
+              <ProtectedRoute>
+                <Reports />
               </ProtectedRoute>
             }
           />

--- a/src/components/calendar/AppointmentDetailsSheet.tsx
+++ b/src/components/calendar/AppointmentDetailsSheet.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Appointment, cancelAppointment } from "@/services/appointments";
+import { Appointment, cancelAppointment, updateAppointmentStatus } from "@/services/appointments";
 import {
   Sheet,
   SheetContent,
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { format } from "date-fns";
 import { ptBR } from "date-fns/locale";
-import { Clock, User, Phone, FileText, Calendar, Sparkles, X } from "lucide-react";
+import { Clock, User, Phone, FileText, Calendar, Sparkles, X, Check, UserX } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
 
@@ -43,6 +43,7 @@ export const AppointmentDetailsSheet = ({
 }: AppointmentDetailsSheetProps) => {
   const { toast } = useToast();
   const [isCancelling, setIsCancelling] = useState(false);
+  const [isUpdatingStatus, setIsUpdatingStatus] = useState(false);
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [isSafariMobile, setIsSafariMobile] = useState(false);
 
@@ -95,7 +96,39 @@ export const AppointmentDetailsSheet = ({
     }
   };
 
-  const canCancel = appointment.status !== "cancelled" && appointment.status !== "completed";
+  const handleStatusChange = async (status: Appointment["status"], successMessage: string) => {
+    if (!appointment.id) return;
+
+    try {
+      setIsUpdatingStatus(true);
+      await updateAppointmentStatus(appointment.id, status);
+      toast({
+        title: successMessage,
+        description: "O status do agendamento foi atualizado.",
+      });
+      onOpenChange(false);
+      if (onAppointmentCancelled) {
+        onAppointmentCancelled();
+      }
+    } catch (error) {
+      toast({
+        title: "Erro ao atualizar",
+        description: "Não foi possível atualizar o agendamento. Tente novamente.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUpdatingStatus(false);
+    }
+  };
+
+  const isTerminalStatus =
+    appointment.status === "cancelled" ||
+    appointment.status === "completed" ||
+    appointment.status === "no_show";
+  const canCancel = !isTerminalStatus;
+  const isPast = appointmentDate.getTime() < Date.now();
+  // Baixa de comparecimento só faz sentido depois do horário e antes de um status terminal
+  const canMarkAttendance = isPast && !isTerminalStatus;
 
   const getStatusBadge = (status: string) => {
     switch (status) {
@@ -107,6 +140,8 @@ export const AppointmentDetailsSheet = ({
         return <Badge className="bg-blue-500">Concluído</Badge>;
       case "cancelled":
         return <Badge variant="destructive">Cancelado</Badge>;
+      case "no_show":
+        return <Badge className="bg-orange-500">Não compareceu</Badge>;
       default:
         return <Badge variant="outline">{status}</Badge>;
     }
@@ -247,6 +282,35 @@ export const AppointmentDetailsSheet = ({
               </>
             )}
           </div>
+
+          {canMarkAttendance && (
+            <>
+              <Separator />
+              <div className="space-y-2">
+                <div className="text-sm text-muted-foreground">Registrar comparecimento</div>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    variant="outline"
+                    className="w-full border-blue-500/40 text-blue-600 hover:bg-blue-500/5 hover:text-blue-700"
+                    disabled={isUpdatingStatus}
+                    onClick={() => handleStatusChange("completed", "Atendimento concluído")}
+                  >
+                    <Check className="w-4 h-4 mr-2" />
+                    Compareceu
+                  </Button>
+                  <Button
+                    variant="outline"
+                    className="w-full border-orange-500/40 text-orange-600 hover:bg-orange-500/5 hover:text-orange-700"
+                    disabled={isUpdatingStatus}
+                    onClick={() => handleStatusChange("no_show", "Falta registrada")}
+                  >
+                    <UserX className="w-4 h-4 mr-2" />
+                    Não compareceu
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
 
           {canCancel && (
             <>

--- a/src/components/reports/AppointmentsTrendChart.tsx
+++ b/src/components/reports/AppointmentsTrendChart.tsx
@@ -1,0 +1,68 @@
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+} from "recharts";
+import { TimeSeriesPoint } from "@/services/reports";
+
+interface AppointmentsTrendChartProps {
+  data: TimeSeriesPoint[];
+}
+
+export const AppointmentsTrendChart = ({ data }: AppointmentsTrendChartProps) => {
+  if (data.length === 0) {
+    return (
+      <div className="h-[260px] flex items-center justify-center text-sm text-muted-foreground">
+        Sem dados no período
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <AreaChart data={data} margin={{ top: 8, right: 8, left: -16, bottom: 0 }}>
+        <defs>
+          <linearGradient id="trendFill" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity={0.35} />
+            <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" vertical={false} />
+        <XAxis
+          dataKey="label"
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          allowDecimals={false}
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          tickLine={false}
+          axisLine={false}
+          width={32}
+        />
+        <Tooltip
+          contentStyle={{
+            background: "hsl(var(--card))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 12,
+            fontSize: 12,
+          }}
+          labelStyle={{ color: "hsl(var(--foreground))" }}
+          formatter={(value: number) => [value, "Agendamentos"]}
+        />
+        <Area
+          type="monotone"
+          dataKey="count"
+          stroke="hsl(var(--primary))"
+          strokeWidth={2}
+          fill="url(#trendFill)"
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+};

--- a/src/components/reports/KpiCard.tsx
+++ b/src/components/reports/KpiCard.tsx
@@ -1,0 +1,47 @@
+import { LucideIcon, TrendingUp, TrendingDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface KpiCardProps {
+  label: string;
+  value: string;
+  icon: LucideIcon;
+  /** Variação relativa vs. período anterior (null quando não há base). */
+  deltaPct?: number | null;
+  /** Quando true, uma queda é considerada positiva (ex.: cancelamentos). */
+  lowerIsBetter?: boolean;
+  hint?: string;
+}
+
+export const KpiCard = ({ label, value, icon: Icon, deltaPct, lowerIsBetter, hint }: KpiCardProps) => {
+  const hasDelta = deltaPct !== undefined && deltaPct !== null && Number.isFinite(deltaPct);
+  const isUp = hasDelta && (deltaPct as number) > 0;
+  const isDown = hasDelta && (deltaPct as number) < 0;
+  const isGood = (isUp && !lowerIsBetter) || (isDown && lowerIsBetter);
+  const isBad = (isUp && lowerIsBetter) || (isDown && !lowerIsBetter);
+
+  return (
+    <div className="bg-card rounded-[20px] border border-border shadow-soft p-5">
+      <div className="flex items-center justify-between mb-3">
+        <div className="w-9 h-9 rounded-xl bg-primary/10 flex items-center justify-center">
+          <Icon className="w-4.5 h-4.5 text-primary" />
+        </div>
+        {hasDelta && (deltaPct as number) !== 0 && (
+          <div
+            className={cn(
+              "flex items-center gap-1 text-xs font-medium",
+              isGood && "text-green-600",
+              isBad && "text-destructive",
+              !isGood && !isBad && "text-muted-foreground"
+            )}
+          >
+            {isUp ? <TrendingUp className="w-3.5 h-3.5" /> : <TrendingDown className="w-3.5 h-3.5" />}
+            {Math.abs((deltaPct as number) * 100).toFixed(0)}%
+          </div>
+        )}
+      </div>
+      <div className="text-2xl font-display font-light text-foreground">{value}</div>
+      <div className="text-xs text-muted-foreground mt-1">{label}</div>
+      {hint && <div className="text-[11px] text-muted-foreground/70 mt-1">{hint}</div>}
+    </div>
+  );
+};

--- a/src/components/reports/PeriodSelector.tsx
+++ b/src/components/reports/PeriodSelector.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from "react";
+import {
+  startOfDay,
+  endOfDay,
+  startOfMonth,
+  endOfMonth,
+  startOfYear,
+  subDays,
+  subMonths,
+  format,
+} from "date-fns";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { ReportPeriod } from "@/services/reports";
+
+export type PeriodPreset = "7d" | "30d" | "this_month" | "last_month" | "this_year" | "custom";
+
+export const buildPeriod = (preset: PeriodPreset, now: Date = new Date()): ReportPeriod => {
+  switch (preset) {
+    case "7d":
+      return { start: startOfDay(subDays(now, 6)), end: endOfDay(now) };
+    case "30d":
+      return { start: startOfDay(subDays(now, 29)), end: endOfDay(now) };
+    case "this_month":
+      return { start: startOfMonth(now), end: endOfDay(now) };
+    case "last_month": {
+      const lastMonth = subMonths(now, 1);
+      return { start: startOfMonth(lastMonth), end: endOfMonth(lastMonth) };
+    }
+    case "this_year":
+      return { start: startOfYear(now), end: endOfDay(now) };
+    default:
+      return { start: startOfDay(subDays(now, 29)), end: endOfDay(now) };
+  }
+};
+
+const PRESET_LABELS: Record<PeriodPreset, string> = {
+  "7d": "Últimos 7 dias",
+  "30d": "Últimos 30 dias",
+  this_month: "Este mês",
+  last_month: "Mês passado",
+  this_year: "Este ano",
+  custom: "Personalizado",
+};
+
+interface PeriodSelectorProps {
+  preset: PeriodPreset;
+  period: ReportPeriod;
+  onPresetChange: (preset: PeriodPreset) => void;
+  onCustomChange: (period: ReportPeriod) => void;
+}
+
+export const PeriodSelector = ({
+  preset,
+  period,
+  onPresetChange,
+  onCustomChange,
+}: PeriodSelectorProps) => {
+  const startValue = useMemo(() => format(period.start, "yyyy-MM-dd"), [period.start]);
+  const endValue = useMemo(() => format(period.end, "yyyy-MM-dd"), [period.end]);
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-2 sm:items-center">
+      <Select value={preset} onValueChange={(v) => onPresetChange(v as PeriodPreset)}>
+        <SelectTrigger className="w-full sm:w-[180px]">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {(Object.keys(PRESET_LABELS) as PeriodPreset[]).map((key) => (
+            <SelectItem key={key} value={key}>
+              {PRESET_LABELS[key]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {preset === "custom" && (
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            value={startValue}
+            max={endValue}
+            onChange={(e) =>
+              onCustomChange({ ...period, start: startOfDay(new Date(e.target.value + "T00:00:00")) })
+            }
+            className="px-3 py-2 bg-secondary rounded-xl border border-border text-sm text-foreground focus:outline-none"
+          />
+          <span className="text-muted-foreground text-sm">até</span>
+          <input
+            type="date"
+            value={endValue}
+            min={startValue}
+            onChange={(e) =>
+              onCustomChange({ ...period, end: endOfDay(new Date(e.target.value + "T00:00:00")) })
+            }
+            className="px-3 py-2 bg-secondary rounded-xl border border-border text-sm text-foreground focus:outline-none"
+          />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/reports/ServicePopularityChart.tsx
+++ b/src/components/reports/ServicePopularityChart.tsx
@@ -1,0 +1,65 @@
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Cell,
+} from "recharts";
+import { ServiceBreakdown } from "@/services/reports";
+
+interface ServicePopularityChartProps {
+  data: ServiceBreakdown[];
+}
+
+export const ServicePopularityChart = ({ data }: ServicePopularityChartProps) => {
+  if (data.length === 0) {
+    return (
+      <div className="h-[260px] flex items-center justify-center text-sm text-muted-foreground">
+        Sem dados no período
+      </div>
+    );
+  }
+
+  const height = Math.max(160, data.length * 44);
+
+  return (
+    <ResponsiveContainer width="100%" height={Math.min(height, 360)}>
+      <BarChart data={data} layout="vertical" margin={{ top: 4, right: 16, left: 8, bottom: 4 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" horizontal={false} />
+        <XAxis
+          type="number"
+          allowDecimals={false}
+          tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          type="category"
+          dataKey="serviceName"
+          width={120}
+          tick={{ fontSize: 12, fill: "hsl(var(--foreground))" }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          cursor={{ fill: "hsl(var(--muted))", opacity: 0.4 }}
+          contentStyle={{
+            background: "hsl(var(--card))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 12,
+            fontSize: 12,
+          }}
+          formatter={(value: number) => [value, "Agendamentos"]}
+        />
+        <Bar dataKey="count" radius={[0, 6, 6, 0]} barSize={22}>
+          {data.map((entry) => (
+            <Cell key={entry.serviceId || entry.serviceName} fill={entry.color} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+};

--- a/src/components/reports/StatusDistributionChart.tsx
+++ b/src/components/reports/StatusDistributionChart.tsx
@@ -1,0 +1,49 @@
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip, Legend } from "recharts";
+import { StatusSlice } from "@/services/reports";
+
+interface StatusDistributionChartProps {
+  data: StatusSlice[];
+}
+
+export const StatusDistributionChart = ({ data }: StatusDistributionChartProps) => {
+  if (data.length === 0) {
+    return (
+      <div className="h-[260px] flex items-center justify-center text-sm text-muted-foreground">
+        Sem dados no período
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="count"
+          nameKey="label"
+          innerRadius={55}
+          outerRadius={85}
+          paddingAngle={2}
+        >
+          {data.map((entry) => (
+            <Cell key={entry.status} fill={entry.color} />
+          ))}
+        </Pie>
+        <Tooltip
+          contentStyle={{
+            background: "hsl(var(--card))",
+            border: "1px solid hsl(var(--border))",
+            borderRadius: 12,
+            fontSize: 12,
+          }}
+          formatter={(value: number, name: string) => [value, name]}
+        />
+        <Legend
+          iconType="circle"
+          wrapperStyle={{ fontSize: 12 }}
+          formatter={(value) => <span className="text-muted-foreground">{value}</span>}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+};

--- a/src/components/reports/TopClientsTable.tsx
+++ b/src/components/reports/TopClientsTable.tsx
@@ -1,0 +1,62 @@
+import { format } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { ClientSummary } from "@/services/reports";
+
+interface TopClientsTableProps {
+  clients: ClientSummary[];
+}
+
+export const TopClientsTable = ({ clients }: TopClientsTableProps) => {
+  if (clients.length === 0) {
+    return (
+      <div className="py-10 text-center text-sm text-muted-foreground">
+        Nenhum cliente no período
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Cliente</TableHead>
+          <TableHead className="hidden sm:table-cell">Telefone</TableHead>
+          <TableHead className="text-center">Agend.</TableHead>
+          <TableHead className="text-right">Último</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {clients.map((client) => (
+          <TableRow key={client.clientPhone || client.clientName}>
+            <TableCell className="font-medium">
+              <div className="flex items-center gap-2">
+                {client.clientName}
+                {client.appointmentsCount >= 2 && (
+                  <Badge variant="secondary" className="text-[10px]">
+                    Recorrente
+                  </Badge>
+                )}
+              </div>
+            </TableCell>
+            <TableCell className="hidden sm:table-cell text-muted-foreground">
+              {client.clientPhone}
+            </TableCell>
+            <TableCell className="text-center">{client.appointmentsCount}</TableCell>
+            <TableCell className="text-right text-muted-foreground">
+              {format(client.lastAppointment, "dd/MM/yyyy", { locale: ptBR })}
+            </TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  );
+};

--- a/src/hooks/use-reports.tsx
+++ b/src/hooks/use-reports.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getReportData,
+  computeMetrics,
+  computeServiceBreakdown,
+  computeTopClients,
+  computeTimeSeries,
+  computeStatusDistribution,
+  pickGranularity,
+  ReportPeriod,
+} from "@/services/reports";
+import { Service } from "@/services/user-services";
+
+interface UseReportsProps {
+  userId: string | null;
+  period: ReportPeriod;
+  services: Service[];
+}
+
+export const useReports = ({ userId, period, services }: UseReportsProps) => {
+  const query = useQuery({
+    queryKey: ["reports", userId, period.start.getTime(), period.end.getTime()],
+    enabled: !!userId,
+    queryFn: async () => {
+      const { current, previous } = await getReportData(userId!, period);
+      const granularity = pickGranularity(period);
+
+      return {
+        appointments: current,
+        metrics: computeMetrics(current),
+        previousMetrics: computeMetrics(previous),
+        serviceBreakdown: computeServiceBreakdown(current, services),
+        topClients: computeTopClients(current),
+        timeSeries: computeTimeSeries(current, granularity),
+        statusDistribution: computeStatusDistribution(current),
+      };
+    },
+  });
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    error: query.error as Error | null,
+    refetch: query.refetch,
+  };
+};

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { Calendar, Clock, Palette, Link as LinkIcon, LogOut, Sparkles, Copy, XCircle } from "lucide-react";
+import { Calendar, Clock, Palette, Link as LinkIcon, LogOut, Sparkles, Copy, XCircle, BarChart3 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
 import { useUserLink } from "@/hooks/use-user-link";
@@ -93,6 +93,12 @@ const Dashboard = () => {
       description: "Visualize e gerencie seus agendamentos",
       icon: Calendar,
       path: "/appointments",
+    },
+    {
+      title: "Relatórios",
+      description: "Acompanhe métricas e o desempenho do seu negócio",
+      icon: BarChart3,
+      path: "/reports",
     },
     {
       title: "Personalização",

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -1,0 +1,252 @@
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ArrowLeft,
+  BarChart3,
+  CalendarCheck,
+  CalendarClock,
+  CheckCircle2,
+  Download,
+  Repeat,
+  Users,
+  UserX,
+  XCircle,
+  AlertTriangle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/use-auth";
+import { useUserServices } from "@/hooks/use-user-services";
+import { useReports } from "@/hooks/use-reports";
+import { percentChange, appointmentsToCsv } from "@/services/reports";
+import { KpiCard } from "@/components/reports/KpiCard";
+import {
+  PeriodSelector,
+  PeriodPreset,
+  buildPeriod,
+} from "@/components/reports/PeriodSelector";
+import { AppointmentsTrendChart } from "@/components/reports/AppointmentsTrendChart";
+import { ServicePopularityChart } from "@/components/reports/ServicePopularityChart";
+import { StatusDistributionChart } from "@/components/reports/StatusDistributionChart";
+import { TopClientsTable } from "@/components/reports/TopClientsTable";
+import { format } from "date-fns";
+import { toast } from "sonner";
+
+const formatMinutes = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60);
+  const mins = Math.round(minutes % 60);
+  if (hours === 0) return `${mins}min`;
+  if (mins === 0) return `${hours}h`;
+  return `${hours}h ${mins}min`;
+};
+
+const Card = ({ title, children }: { title: string; children: React.ReactNode }) => (
+  <div className="bg-card rounded-[20px] border border-border shadow-soft p-6">
+    <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground mb-4">
+      {title}
+    </p>
+    {children}
+  </div>
+);
+
+const Reports = () => {
+  const navigate = useNavigate();
+  const { userData } = useAuth();
+  const { services } = useUserServices({ userId: userData?.uid || null });
+
+  const [preset, setPreset] = useState<PeriodPreset>("30d");
+  const [customPeriod, setCustomPeriod] = useState(buildPeriod("30d"));
+
+  const period = preset === "custom" ? customPeriod : buildPeriod(preset);
+
+  const { data, isLoading, error } = useReports({
+    userId: userData?.uid || null,
+    period,
+    services,
+  });
+
+  const metrics = data?.metrics;
+  const previous = data?.previousMetrics;
+
+  const handleExport = () => {
+    if (!data || data.appointments.length === 0) {
+      toast.error("Não há agendamentos para exportar neste período");
+      return;
+    }
+    const csv = appointmentsToCsv(data.appointments);
+    const blob = new Blob(["﻿" + csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `relatorio_${format(period.start, "yyyy-MM-dd")}_${format(period.end, "yyyy-MM-dd")}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+    toast.success("Relatório exportado");
+  };
+
+  const isEmpty = !isLoading && !error && (data?.appointments.length ?? 0) === 0;
+
+  const kpis = useMemo(() => {
+    if (!metrics) return [];
+    return [
+      {
+        label: "Total de agendamentos",
+        value: String(metrics.totalAppointments),
+        icon: CalendarCheck,
+        deltaPct: previous ? percentChange(metrics.totalAppointments, previous.totalAppointments) : null,
+      },
+      {
+        label: "Atendimentos concluídos",
+        value: String(metrics.completed),
+        icon: CheckCircle2,
+        deltaPct: previous ? percentChange(metrics.completed, previous.completed) : null,
+      },
+      {
+        label: "Taxa de comparecimento",
+        value: `${(metrics.attendanceRate * 100).toFixed(0)}%`,
+        icon: BarChart3,
+        deltaPct: previous ? percentChange(metrics.attendanceRate, previous.attendanceRate) : null,
+      },
+      {
+        label: "Taxa de cancelamento",
+        value: `${(metrics.cancellationRate * 100).toFixed(0)}%`,
+        icon: XCircle,
+        deltaPct: previous ? percentChange(metrics.cancellationRate, previous.cancellationRate) : null,
+        lowerIsBetter: true,
+      },
+      {
+        label: "Faltas (não compareceu)",
+        value: String(metrics.noShow),
+        icon: UserX,
+        deltaPct: previous ? percentChange(metrics.noShow, previous.noShow) : null,
+        lowerIsBetter: true,
+      },
+      {
+        label: "Clientes únicos",
+        value: String(metrics.uniqueClients),
+        icon: Users,
+        deltaPct: previous ? percentChange(metrics.uniqueClients, previous.uniqueClients) : null,
+      },
+      {
+        label: "Clientes recorrentes",
+        value: String(metrics.returningClients),
+        icon: Repeat,
+      },
+      {
+        label: "Tempo agendado",
+        value: formatMinutes(metrics.totalScheduledMinutes),
+        icon: CalendarClock,
+        hint: "Exclui cancelados",
+      },
+    ];
+  }, [metrics, previous]);
+
+  return (
+    <div className="min-h-screen bg-background animate-fade-in">
+      <div className="max-w-6xl mx-auto px-6 py-10 space-y-8">
+
+        {/* Header */}
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-4">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => navigate("/dashboard")}
+              className="border-border text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="w-4 h-4" />
+            </Button>
+            <div>
+              <h1 className="page-title">Relatórios</h1>
+              <p className="page-subtitle">Acompanhe o desempenho do seu negócio</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <PeriodSelector
+              preset={preset}
+              period={period}
+              onPresetChange={setPreset}
+              onCustomChange={setCustomPeriod}
+            />
+            <Button
+              variant="outline"
+              onClick={handleExport}
+              disabled={isLoading || isEmpty}
+              className="border-primary/30 text-primary hover:bg-primary/5"
+            >
+              <Download className="w-4 h-4" />
+              Exportar
+            </Button>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="text-center py-24 text-muted-foreground space-y-3">
+            <div className="w-12 h-12 rounded-full border-2 border-primary/20 border-t-primary animate-spin mx-auto" />
+            <p className="text-sm">Carregando relatórios...</p>
+          </div>
+        ) : error ? (
+          <div className="text-center py-24 text-destructive">
+            <p className="text-sm">Erro ao carregar relatórios: {error.message}</p>
+          </div>
+        ) : isEmpty ? (
+          <div className="bg-card rounded-[20px] border border-border shadow-soft text-center py-24 px-6 space-y-3">
+            <BarChart3 className="w-12 h-12 mx-auto text-muted-foreground/30" />
+            <p className="text-sm text-muted-foreground">
+              Ainda não há agendamentos neste período.
+            </p>
+            <p className="text-xs text-muted-foreground/70">
+              Experimente selecionar um intervalo maior.
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Alerta de faltas em aberto */}
+            {metrics && metrics.openNoShow > 0 && (
+              <div className="flex items-start gap-3 p-4 rounded-2xl bg-orange-500/10 border border-orange-500/20">
+                <AlertTriangle className="w-5 h-5 text-orange-600 shrink-0 mt-0.5" />
+                <div className="text-sm">
+                  <span className="font-medium text-foreground">
+                    {metrics.openNoShow} atendimento(s) pendente(s) de baixa.
+                  </span>{" "}
+                  <span className="text-muted-foreground">
+                    São agendamentos que já passaram e seguem como pendentes/confirmados.
+                    Marque na Agenda se o cliente compareceu ou não.
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* KPIs */}
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+              {kpis.map((kpi) => (
+                <KpiCard key={kpi.label} {...kpi} />
+              ))}
+            </div>
+
+            {/* Tendência */}
+            <Card title="Agendamentos ao longo do tempo">
+              <AppointmentsTrendChart data={data?.timeSeries ?? []} />
+            </Card>
+
+            {/* Serviços + Status */}
+            <div className="grid lg:grid-cols-2 gap-6">
+              <Card title="Serviços mais populares">
+                <ServicePopularityChart data={data?.serviceBreakdown ?? []} />
+              </Card>
+              <Card title="Distribuição por status">
+                <StatusDistributionChart data={data?.statusDistribution ?? []} />
+              </Card>
+            </div>
+
+            {/* Top clientes */}
+            <Card title="Clientes que mais agendaram">
+              <TopClientsTable clients={data?.topClients ?? []} />
+            </Card>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Reports;

--- a/src/pages/Reports.tsx
+++ b/src/pages/Reports.tsx
@@ -56,7 +56,10 @@ const Reports = () => {
   const [preset, setPreset] = useState<PeriodPreset>("30d");
   const [customPeriod, setCustomPeriod] = useState(buildPeriod("30d"));
 
-  const period = preset === "custom" ? customPeriod : buildPeriod(preset);
+  const period = useMemo(
+    () => (preset === "custom" ? customPeriod : buildPeriod(preset)),
+    [preset, customPeriod]
+  );
 
   const { data, isLoading, error } = useReports({
     userId: userData?.uid || null,

--- a/src/services/appointments.ts
+++ b/src/services/appointments.ts
@@ -17,7 +17,7 @@ export interface Appointment {
   dateTime: Timestamp;
   duration?: number;
   durationUnit?: "min" | "hour";
-  status: "pending" | "confirmed" | "cancelled" | "completed";
+  status: "pending" | "confirmed" | "cancelled" | "completed" | "no_show";
   googleCalendarEventId?: string;
   createdAt: Timestamp;
   updatedAt: Timestamp;
@@ -172,6 +172,22 @@ export const getBookedSlots = async (
   } catch (error) {
     console.error("Erro ao buscar slots ocupados:", error);
     return [];
+  }
+};
+
+export const updateAppointmentStatus = async (
+  appointmentId: string,
+  status: Appointment["status"]
+): Promise<void> => {
+  try {
+    const appointmentRef = doc(db, COLLECTION_NAME, appointmentId);
+    await updateDoc(appointmentRef, {
+      status,
+      updatedAt: Timestamp.now(),
+    });
+  } catch (error) {
+    console.error("Erro ao atualizar status do agendamento:", error);
+    throw error;
   }
 };
 

--- a/src/services/reports.test.ts
+++ b/src/services/reports.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { Timestamp } from "firebase/firestore";
+import {
+  computeMetrics,
+  computeServiceBreakdown,
+  computeTopClients,
+  computeTimeSeries,
+  computeStatusDistribution,
+  getPreviousPeriod,
+  pickGranularity,
+  percentChange,
+  appointmentsToCsv,
+} from "./reports";
+import { Appointment } from "./appointments";
+import { Service } from "./user-services";
+
+const makeAppointment = (overrides: Partial<Appointment> = {}): Appointment => {
+  const date = overrides.dateTime?.toDate() ?? new Date("2026-06-10T14:00:00");
+  return {
+    id: Math.random().toString(36).slice(2),
+    userId: "user-1",
+    serviceId: "svc-1",
+    serviceName: "Corte",
+    clientName: "Ana",
+    clientPhone: "11999990000",
+    date: "2026-06-10",
+    time: "14:00",
+    dateTime: Timestamp.fromDate(date),
+    duration: 30,
+    durationUnit: "min",
+    status: "completed",
+    createdAt: Timestamp.fromDate(date),
+    updatedAt: Timestamp.fromDate(date),
+    ...overrides,
+  };
+};
+
+const services: Service[] = [
+  { id: "svc-1", name: "Corte", color: "#111111", duration: 30, durationUnit: "min", advanceDays: 1 },
+  { id: "svc-2", name: "Coloração", color: "#222222", duration: 2, durationUnit: "hour", advanceDays: 1 },
+];
+
+describe("computeMetrics", () => {
+  it("retorna zeros para período vazio", () => {
+    const m = computeMetrics([]);
+    expect(m.totalAppointments).toBe(0);
+    expect(m.cancellationRate).toBe(0);
+    expect(m.attendanceRate).toBe(0);
+    expect(m.uniqueClients).toBe(0);
+    expect(m.returningClients).toBe(0);
+  });
+
+  it("conta status, cancelamento e comparecimento", () => {
+    const appts = [
+      makeAppointment({ status: "completed" }),
+      makeAppointment({ status: "completed" }),
+      makeAppointment({ status: "cancelled" }),
+      makeAppointment({ status: "no_show" }),
+    ];
+    const m = computeMetrics(appts);
+    expect(m.totalAppointments).toBe(4);
+    expect(m.completed).toBe(2);
+    expect(m.cancelled).toBe(1);
+    expect(m.noShow).toBe(1);
+    expect(m.cancellationRate).toBeCloseTo(1 / 4);
+    // completed / (completed + cancelled + no_show) = 2 / 4
+    expect(m.attendanceRate).toBeCloseTo(2 / 4);
+  });
+
+  it("infere faltas em aberto (passado e ainda pending/confirmed)", () => {
+    const now = new Date("2026-06-15T00:00:00");
+    const appts = [
+      makeAppointment({ status: "pending", dateTime: Timestamp.fromDate(new Date("2026-06-10T14:00:00")) }),
+      makeAppointment({ status: "confirmed", dateTime: Timestamp.fromDate(new Date("2026-06-11T14:00:00")) }),
+      // futuro: não conta como falta em aberto
+      makeAppointment({ status: "confirmed", dateTime: Timestamp.fromDate(new Date("2026-06-20T14:00:00")) }),
+      // concluído no passado: não conta
+      makeAppointment({ status: "completed", dateTime: Timestamp.fromDate(new Date("2026-06-09T14:00:00")) }),
+    ];
+    const m = computeMetrics(appts, now);
+    expect(m.openNoShow).toBe(2);
+  });
+
+  it("conta clientes únicos e recorrentes por telefone normalizado", () => {
+    const appts = [
+      makeAppointment({ clientPhone: "(11) 99999-0000" }),
+      makeAppointment({ clientPhone: "11999990000" }),
+      makeAppointment({ clientPhone: "11888887777" }),
+    ];
+    const m = computeMetrics(appts);
+    expect(m.uniqueClients).toBe(2);
+    expect(m.returningClients).toBe(1);
+  });
+
+  it("exclui cancelados do tempo agendado e converte horas", () => {
+    const appts = [
+      makeAppointment({ duration: 30, durationUnit: "min", status: "completed" }),
+      makeAppointment({ duration: 2, durationUnit: "hour", status: "confirmed" }),
+      makeAppointment({ duration: 60, durationUnit: "min", status: "cancelled" }),
+    ];
+    const m = computeMetrics(appts);
+    expect(m.totalScheduledMinutes).toBe(30 + 120);
+  });
+});
+
+describe("computeServiceBreakdown", () => {
+  it("agrupa por serviço, ordena por contagem e calcula percentual", () => {
+    const appts = [
+      makeAppointment({ serviceId: "svc-1", serviceName: "Corte" }),
+      makeAppointment({ serviceId: "svc-2", serviceName: "Coloração", duration: 2, durationUnit: "hour" }),
+      makeAppointment({ serviceId: "svc-2", serviceName: "Coloração", duration: 2, durationUnit: "hour" }),
+    ];
+    const result = computeServiceBreakdown(appts, services);
+    expect(result[0].serviceId).toBe("svc-2");
+    expect(result[0].count).toBe(2);
+    expect(result[0].percentage).toBeCloseTo(2 / 3);
+    expect(result[0].color).toBe("#222222");
+    expect(result[0].totalMinutes).toBe(240);
+  });
+
+  it("usa fallback para serviço removido", () => {
+    const appts = [makeAppointment({ serviceId: "deleted", serviceName: "Antigo" })];
+    const result = computeServiceBreakdown(appts, services);
+    expect(result[0].serviceName).toBe("Antigo");
+    expect(result[0].color).toBeTruthy();
+  });
+});
+
+describe("computeTopClients", () => {
+  it("ordena por número de agendamentos e respeita o limite", () => {
+    const appts = [
+      makeAppointment({ clientName: "Ana", clientPhone: "111", dateTime: Timestamp.fromDate(new Date("2026-06-01T10:00:00")) }),
+      makeAppointment({ clientName: "Ana", clientPhone: "111", dateTime: Timestamp.fromDate(new Date("2026-06-10T10:00:00")) }),
+      makeAppointment({ clientName: "Bia", clientPhone: "222", dateTime: Timestamp.fromDate(new Date("2026-06-05T10:00:00")) }),
+    ];
+    const result = computeTopClients(appts, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].clientName).toBe("Ana");
+    expect(result[0].appointmentsCount).toBe(2);
+    expect(result[0].lastAppointment).toEqual(new Date("2026-06-10T10:00:00"));
+  });
+});
+
+describe("computeTimeSeries", () => {
+  it("agrupa por dia e ordena cronologicamente", () => {
+    const appts = [
+      makeAppointment({ dateTime: Timestamp.fromDate(new Date("2026-06-10T09:00:00")) }),
+      makeAppointment({ dateTime: Timestamp.fromDate(new Date("2026-06-10T15:00:00")) }),
+      makeAppointment({ dateTime: Timestamp.fromDate(new Date("2026-06-08T15:00:00")) }),
+    ];
+    const series = computeTimeSeries(appts, "day");
+    expect(series).toHaveLength(2);
+    expect(series[0].date).toBe("2026-06-08");
+    expect(series[1].count).toBe(2);
+  });
+});
+
+describe("computeStatusDistribution", () => {
+  it("inclui apenas status presentes, na ordem definida", () => {
+    const appts = [
+      makeAppointment({ status: "completed" }),
+      makeAppointment({ status: "cancelled" }),
+    ];
+    const dist = computeStatusDistribution(appts);
+    expect(dist.map((s) => s.status)).toEqual(["completed", "cancelled"]);
+  });
+});
+
+describe("getPreviousPeriod", () => {
+  it("retorna período anterior de mesma duração", () => {
+    const period = { start: new Date("2026-06-08T00:00:00"), end: new Date("2026-06-15T00:00:00") };
+    const prev = getPreviousPeriod(period);
+    expect(prev.end).toEqual(period.start);
+    expect(prev.start).toEqual(new Date("2026-06-01T00:00:00"));
+  });
+});
+
+describe("pickGranularity", () => {
+  it("escolhe granularidade conforme tamanho do período", () => {
+    expect(pickGranularity({ start: new Date("2026-06-01"), end: new Date("2026-06-20") })).toBe("day");
+    expect(pickGranularity({ start: new Date("2026-04-01"), end: new Date("2026-06-01") })).toBe("week");
+    expect(pickGranularity({ start: new Date("2026-01-01"), end: new Date("2026-12-31") })).toBe("month");
+  });
+});
+
+describe("percentChange", () => {
+  it("retorna null quando a base é zero", () => {
+    expect(percentChange(5, 0)).toBeNull();
+  });
+  it("calcula variação relativa", () => {
+    expect(percentChange(150, 100)).toBeCloseTo(0.5);
+    expect(percentChange(50, 100)).toBeCloseTo(-0.5);
+  });
+});
+
+describe("appointmentsToCsv", () => {
+  it("gera cabeçalho e linhas com escaping", () => {
+    const csv = appointmentsToCsv([
+      makeAppointment({ clientName: "Ana, Maria", status: "completed" }),
+    ]);
+    const lines = csv.split("\n");
+    expect(lines[0]).toContain("Cliente");
+    expect(lines[1]).toContain('"Ana, Maria"');
+    expect(lines[1]).toContain("Concluído");
+  });
+});

--- a/src/services/reports.test.ts
+++ b/src/services/reports.test.ts
@@ -170,7 +170,8 @@ describe("getPreviousPeriod", () => {
   it("retorna período anterior de mesma duração", () => {
     const period = { start: new Date("2026-06-08T00:00:00"), end: new Date("2026-06-15T00:00:00") };
     const prev = getPreviousPeriod(period);
-    expect(prev.end).toEqual(period.start);
+    // fim do período anterior fica 1ms antes do início do atual (sem sobreposição)
+    expect(prev.end).toEqual(new Date(period.start.getTime() - 1));
     expect(prev.start).toEqual(new Date("2026-06-01T00:00:00"));
   });
 });

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -88,9 +88,12 @@ const getMinutes = (appt: Appointment): number => {
  */
 export const getPreviousPeriod = (period: ReportPeriod): ReportPeriod => {
   const durationMs = period.end.getTime() - period.start.getTime();
+  // -1ms no fim evita sobreposição: getAppointmentsByDateRange é inclusivo nas
+  // duas pontas, então um agendamento exatamente em period.start não pode cair
+  // no período atual e no anterior ao mesmo tempo.
   return {
     start: new Date(period.start.getTime() - durationMs),
-    end: new Date(period.start.getTime()),
+    end: new Date(period.start.getTime() - 1),
   };
 };
 

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -1,0 +1,333 @@
+import { format, startOfWeek, differenceInCalendarDays } from "date-fns";
+import { ptBR } from "date-fns/locale";
+import { Appointment, getAppointmentsByDateRange } from "./appointments";
+import { Service } from "./user-services";
+
+export interface ReportPeriod {
+  start: Date;
+  end: Date;
+}
+
+export interface ReportMetrics {
+  totalAppointments: number;
+  completed: number;
+  cancelled: number;
+  pending: number;
+  confirmed: number;
+  noShow: number;
+  /** Agendamentos passados ainda em pending/confirmed (faltas em aberto, inferido). */
+  openNoShow: number;
+  /** cancelled / total (0..1). */
+  cancellationRate: number;
+  /** completed / (completed + cancelled + no_show) (0..1). */
+  attendanceRate: number;
+  uniqueClients: number;
+  returningClients: number;
+  totalScheduledMinutes: number;
+}
+
+export interface ServiceBreakdown {
+  serviceId: string;
+  serviceName: string;
+  color: string;
+  count: number;
+  percentage: number;
+  totalMinutes: number;
+}
+
+export interface ClientSummary {
+  clientName: string;
+  clientPhone: string;
+  appointmentsCount: number;
+  lastAppointment: Date;
+}
+
+export interface TimeSeriesPoint {
+  label: string;
+  date: string;
+  count: number;
+}
+
+export interface StatusSlice {
+  status: Appointment["status"];
+  label: string;
+  count: number;
+  color: string;
+}
+
+export type Granularity = "day" | "week" | "month";
+
+const DEFAULT_SERVICE_COLOR = "#C45C58";
+
+export const STATUS_LABELS: Record<Appointment["status"], string> = {
+  pending: "Pendente",
+  confirmed: "Confirmado",
+  completed: "Concluído",
+  cancelled: "Cancelado",
+  no_show: "Não compareceu",
+};
+
+export const STATUS_COLORS: Record<Appointment["status"], string> = {
+  pending: "#EAB308",
+  confirmed: "#22C55E",
+  completed: "#3B82F6",
+  cancelled: "#EF4444",
+  no_show: "#F97316",
+};
+
+/** Normaliza telefone para identidade de cliente (somente dígitos). */
+const normalizePhone = (phone: string): string => (phone || "").replace(/\D/g, "");
+
+const getMinutes = (appt: Appointment): number => {
+  if (!appt.duration) return 0;
+  return appt.durationUnit === "hour" ? appt.duration * 60 : appt.duration;
+};
+
+/**
+ * Calcula o período imediatamente anterior, de mesma duração, para comparação.
+ */
+export const getPreviousPeriod = (period: ReportPeriod): ReportPeriod => {
+  const durationMs = period.end.getTime() - period.start.getTime();
+  return {
+    start: new Date(period.start.getTime() - durationMs),
+    end: new Date(period.start.getTime()),
+  };
+};
+
+/** Escolhe a granularidade do gráfico de tendência conforme o tamanho do período. */
+export const pickGranularity = (period: ReportPeriod): Granularity => {
+  const days = differenceInCalendarDays(period.end, period.start);
+  if (days <= 31) return "day";
+  if (days <= 92) return "week";
+  return "month";
+};
+
+export const computeMetrics = (appts: Appointment[], now: Date = new Date()): ReportMetrics => {
+  const counts = { pending: 0, confirmed: 0, completed: 0, cancelled: 0, no_show: 0 };
+  let openNoShow = 0;
+  let totalScheduledMinutes = 0;
+
+  const phoneCounts = new Map<string, number>();
+
+  for (const appt of appts) {
+    counts[appt.status] = (counts[appt.status] ?? 0) + 1;
+
+    if (
+      (appt.status === "pending" || appt.status === "confirmed") &&
+      appt.dateTime.toDate().getTime() < now.getTime()
+    ) {
+      openNoShow += 1;
+    }
+
+    if (appt.status !== "cancelled") {
+      totalScheduledMinutes += getMinutes(appt);
+    }
+
+    const phone = normalizePhone(appt.clientPhone);
+    if (phone) {
+      phoneCounts.set(phone, (phoneCounts.get(phone) ?? 0) + 1);
+    }
+  }
+
+  const total = appts.length;
+  const attendanceDenominator = counts.completed + counts.cancelled + counts.no_show;
+  const uniqueClients = phoneCounts.size;
+  let returningClients = 0;
+  phoneCounts.forEach((count) => {
+    if (count >= 2) returningClients += 1;
+  });
+
+  return {
+    totalAppointments: total,
+    completed: counts.completed,
+    cancelled: counts.cancelled,
+    pending: counts.pending,
+    confirmed: counts.confirmed,
+    noShow: counts.no_show,
+    openNoShow,
+    cancellationRate: total > 0 ? counts.cancelled / total : 0,
+    attendanceRate: attendanceDenominator > 0 ? counts.completed / attendanceDenominator : 0,
+    uniqueClients,
+    returningClients,
+    totalScheduledMinutes,
+  };
+};
+
+export const computeServiceBreakdown = (
+  appts: Appointment[],
+  services: Service[]
+): ServiceBreakdown[] => {
+  const serviceMap = new Map(services.map((s) => [s.id, s]));
+  const grouped = new Map<string, ServiceBreakdown>();
+
+  for (const appt of appts) {
+    const service = serviceMap.get(appt.serviceId);
+    const key = appt.serviceId || appt.serviceName;
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.count += 1;
+      existing.totalMinutes += getMinutes(appt);
+    } else {
+      grouped.set(key, {
+        serviceId: appt.serviceId,
+        serviceName: service?.name ?? appt.serviceName ?? "Serviço removido",
+        color: service?.color ?? DEFAULT_SERVICE_COLOR,
+        count: 1,
+        percentage: 0,
+        totalMinutes: getMinutes(appt),
+      });
+    }
+  }
+
+  const total = appts.length;
+  const result = Array.from(grouped.values());
+  result.forEach((item) => {
+    item.percentage = total > 0 ? item.count / total : 0;
+  });
+
+  return result.sort((a, b) => b.count - a.count);
+};
+
+export const computeTopClients = (appts: Appointment[], limit = 10): ClientSummary[] => {
+  const grouped = new Map<string, ClientSummary>();
+
+  for (const appt of appts) {
+    const phone = normalizePhone(appt.clientPhone);
+    const key = phone || appt.clientName;
+    if (!key) continue;
+
+    const date = appt.dateTime.toDate();
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.appointmentsCount += 1;
+      if (date > existing.lastAppointment) {
+        existing.lastAppointment = date;
+        existing.clientName = appt.clientName;
+      }
+    } else {
+      grouped.set(key, {
+        clientName: appt.clientName,
+        clientPhone: appt.clientPhone,
+        appointmentsCount: 1,
+        lastAppointment: date,
+      });
+    }
+  }
+
+  return Array.from(grouped.values())
+    .sort(
+      (a, b) =>
+        b.appointmentsCount - a.appointmentsCount ||
+        b.lastAppointment.getTime() - a.lastAppointment.getTime()
+    )
+    .slice(0, limit);
+};
+
+const bucketKey = (date: Date, granularity: Granularity): { key: string; label: string } => {
+  switch (granularity) {
+    case "week": {
+      const weekStart = startOfWeek(date, { weekStartsOn: 1 });
+      return { key: format(weekStart, "yyyy-MM-dd"), label: format(weekStart, "dd/MM") };
+    }
+    case "month":
+      return { key: format(date, "yyyy-MM"), label: format(date, "MMM/yy", { locale: ptBR }) };
+    case "day":
+    default:
+      return { key: format(date, "yyyy-MM-dd"), label: format(date, "dd/MM") };
+  }
+};
+
+export const computeTimeSeries = (
+  appts: Appointment[],
+  granularity: Granularity
+): TimeSeriesPoint[] => {
+  const grouped = new Map<string, TimeSeriesPoint>();
+
+  for (const appt of appts) {
+    const { key, label } = bucketKey(appt.dateTime.toDate(), granularity);
+    const existing = grouped.get(key);
+    if (existing) {
+      existing.count += 1;
+    } else {
+      grouped.set(key, { date: key, label, count: 1 });
+    }
+  }
+
+  return Array.from(grouped.values()).sort((a, b) => a.date.localeCompare(b.date));
+};
+
+export const computeStatusDistribution = (appts: Appointment[]): StatusSlice[] => {
+  const order: Appointment["status"][] = [
+    "completed",
+    "confirmed",
+    "pending",
+    "no_show",
+    "cancelled",
+  ];
+  const counts = new Map<Appointment["status"], number>();
+  for (const appt of appts) {
+    counts.set(appt.status, (counts.get(appt.status) ?? 0) + 1);
+  }
+
+  return order
+    .map((status) => ({
+      status,
+      label: STATUS_LABELS[status],
+      count: counts.get(status) ?? 0,
+      color: STATUS_COLORS[status],
+    }))
+    .filter((slice) => slice.count > 0);
+};
+
+/**
+ * Busca os agendamentos do período atual e do período anterior (mesma duração)
+ * para alimentar todos os cálculos e comparações do relatório.
+ */
+export const getReportData = async (
+  userId: string,
+  period: ReportPeriod
+): Promise<{ current: Appointment[]; previous: Appointment[] }> => {
+  const previousPeriod = getPreviousPeriod(period);
+  const [current, previous] = await Promise.all([
+    getAppointmentsByDateRange(userId, period.start, period.end),
+    getAppointmentsByDateRange(userId, previousPeriod.start, previousPeriod.end),
+  ]);
+  return { current, previous };
+};
+
+/** Variação percentual entre dois valores (null quando a base é zero). */
+export const percentChange = (current: number, previous: number): number | null => {
+  if (previous === 0) return null;
+  return (current - previous) / previous;
+};
+
+const csvEscape = (value: string | number): string => {
+  const str = String(value ?? "");
+  if (/[",\n;]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+};
+
+/** Gera o conteúdo CSV da lista de agendamentos de um período. */
+export const appointmentsToCsv = (appts: Appointment[]): string => {
+  const header = ["Data", "Horário", "Cliente", "Telefone", "Serviço", "Status", "Duração (min)"];
+  const rows = appts
+    .slice()
+    .sort((a, b) => a.dateTime.toMillis() - b.dateTime.toMillis())
+    .map((appt) => {
+      const date = appt.dateTime.toDate();
+      return [
+        format(date, "dd/MM/yyyy"),
+        format(date, "HH:mm"),
+        appt.clientName,
+        appt.clientPhone,
+        appt.serviceName,
+        STATUS_LABELS[appt.status] ?? appt.status,
+        getMinutes(appt),
+      ]
+        .map(csvEscape)
+        .join(",");
+    });
+  return [header.map(csvEscape).join(","), ...rows].join("\n");
+};


### PR DESCRIPTION
## Resumo

Adiciona a feature completa de **relatórios/analytics** para a profissional, baseada nos dados de agendamentos. Inclui o documento de planejamento (`docs/RELATORIOS_PROFISSIONAL.md`) e a implementação de todas as fases.

## Decisões de escopo (alinhadas)

- **Receita/faturamento fora desta versão** — foco em métricas operacionais.
- **Página dedicada `/reports`** acessível por card no Dashboard.
- **No-show incluído**: novo status `no_show` + captura manual na Agenda + inferência de faltas em aberto.

## O que foi implementado

**Fase 0 — No-show**
- Status `no_show` no modelo `Appointment` (aditivo, sem migração)
- `updateAppointmentStatus()` em `services/appointments.ts`
- Ações **"Compareceu"** / **"Não compareceu"** no `AppointmentDetailsSheet` (para agendamentos passados) + badge de no-show

**Fases 1–5 — Relatórios**
- `services/reports.ts`: agregações **puras** (métricas, breakdown por serviço, top clientes, série temporal, distribuição por status, comparação de período, geração de CSV)
- **15 testes unitários** das agregações (`reports.test.ts`)
- `hooks/use-reports.tsx`: hook com TanStack Query
- Página `/reports`:
  - KPIs (total, concluídos, taxa de comparecimento, cancelamento, faltas, clientes únicos/recorrentes, tempo agendado) com **variação % vs. período anterior**
  - Gráficos: tendência (área), serviços populares (barras), distribuição por status (donut)
  - Tabela de top clientes (com selo "recorrente")
  - Alerta de **faltas em aberto**
  - Filtro de período (7d / 30d / mês atual / mês passado / ano / personalizado)
  - **Exportação CSV**
- Card "Relatórios" no Dashboard + rota protegida

## Validação

- ✅ `tsc --noEmit` limpo
- ✅ 49 testes passando (15 novos)
- ✅ `npm run build` OK
- ✅ Lint dos arquivos novos sem erros (apenas 1 warning de fast-refresh, padrão já presente no projeto)

## Sem novas dependências
Recharts já estava instalado. Única mudança de modelo: novo valor de status `no_show` (aditivo).

https://claude.ai/code/session_01FfpbxK2a8ZAFgsYt5feirM