### PR TITLE
Use web_profile_info endpoint for Instagram scraping

### DIFF
--- a/fire-functions/functions/src/use-cases/scrape-instagram-posts.use-case.ts
+++ b/fire-functions/functions/src/use-cases/scrape-instagram-posts.use-case.ts
@@ -28,7 +28,7 @@ interface GraphQLPost {
 }
 
 interface InstagramProfileResponse {
-  graphql?: {
+  data?: {
     user?: {
       edge_owner_to_timeline_media?: {
         edges?: GraphQLPost[];
@@ -99,7 +99,9 @@ function fetchJson(url: string): Promise<unknown> {
 }
 
 async function fetchLatestPosts(username: string, count = 3): Promise<InstagramPost[]> {
-  const url = `https://www.instagram.com/${username}/?__a=1&__d=dis`;
+  const url =
+    "https://i.instagram.com/api/v1/users/web_profile_info/" +
+    `?username=${encodeURIComponent(username)}`;
 
   let json: unknown;
   try {
@@ -117,7 +119,7 @@ async function fetchLatestPosts(username: string, count = 3): Promise<InstagramP
 
   const edges: GraphQLPost[] =
     (json as InstagramProfileResponse)
-      ?.graphql
+      ?.data
       ?.user
       ?.edge_owner_to_timeline_media
       ?.edges ?? [];


### PR DESCRIPTION
## Contexto

Os logs do job semanal de scraping mostravam:

```
Could not fetch @vanessatrega.nails: Instagram returned an empty response body
No posts to save for user ...; keeping existing data
Instagram scrape job finished — success: 0, skipped: 5, errors: 0
```

Após investigação, **isso não era um bug na nossa lógica** — a function já degrada graciosamente (mantém os dados antigos, job fica verde). A causa raiz é que o endpoint `?__a=1&__d=dis` foi em grande parte **descontinuado pelo Instagram** e frequentemente retorna corpo vazio ou redireciona para login.

## Mudança

Troca para o endpoint mais robusto:

`https://i.instagram.com/api/v1/users/web_profile_info/?username=<username>`

- A estrutura da resposta muda de `graphql.user` para `data.user` — parsing atualizado.
- O header `X-IG-App-ID` (exigido por esse endpoint) já estava sendo enviado.
- O tratamento de bloqueio/resposta vazia permanece igual (degradação graciosa, dados preservados).

## Limitação que permanece

Requisições vindas de IPs de nuvem (Cloud Run) ainda podem ser bloqueadas pelo Instagram. Caso o bloqueio persista, o próximo passo seria adicionar proxy residencial / serviço de scraping de terceiros (opção 2 discutida).

## Verificação

- `npm run build` → ✅ exit 0
- `npm run lint` → ✅ exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011BpeobE2KBuMKACQdQH1hf)_